### PR TITLE
fix(datamodel): use correct datamodel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN pip install -r requirements.txt \
     && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>peregrine/version_data.py \
     && cd /peregrine/src/gdcdictionary && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
     && DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/peregrine/peregrine/version_data.py \
+    && python setup.py install \
     && rm /etc/nginx/sites-enabled/default \
     && ln -s /etc/nginx/sites-available/uwsgi.conf /etc/nginx/sites-enabled/uwsgi.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -744,7 +744,8 @@ def create_root_fields(fields):
         def count_resolver(self, info, cls=cls, gql_object=gql_object, **args):
             q = get_authorized_query(cls)
             q = apply_query_args(q, args, info)
-            #q = q.with_entities(sa.distinct(cls.node_id))
+            if 'with_path_to' in args or 'with_path_to_any' in args:
+                q = q.with_entities(sa.distinct(cls.node_id))
             q = q.limit(args.get('first', None))
             return q.count()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,9 +29,9 @@ graphene==2.0.1
 graphql-relay==0.4.5
 cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
--e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.1#egg=cdis_oauth2client
+-e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 -e git+https://git@github.com/uc-cdis/datadictionary.git@0.1.1#egg=gdcdictionary
--e git+https://git@github.com/NCI-GDC/gdcdatamodel.git@568aa07e686fd06d116f67521bb5c8db672cd1cd#egg=gdcdatamodel
+-e git+https://git@github.com/NCI-GDC/gdcdatamodel.git@1.2.0#egg=gdcdatamodel
 -e git+https://git@github.com/NCI-GDC/psqlgraph.git@5cddf49dd03a25bd4e553161d7ad7b9a6fe0ac0d#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 -e git+https://git@github.com/uc-cdis/userdatamodel.git@1.0.2#egg=userdatamodel


### PR DESCRIPTION
the master branch of peregrine use an old version of gdcdatamodel which doesn't respect dictionary pulled from s3
also fix the docker file to install peregrine so that the logs doesn't complain about can't find peregrine.api