### PR TITLE
PXD-1564 Feat/category arg

### DIFF
--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -393,19 +393,19 @@ def resolve_node(self, info, **args):
     """
 
     # get the list of categories queried by the user
-    # if no specified category, get the list of all categories
-    subclasses_labels = [
-        node
-        for node in dictionary.schema
-        if (not 'category' in args) or (dictionary.schema[node]['category'] in args['category'])
-    ]
-
-    # get the subclass for each category
-    subclasses = [
-        node
-        for node in psqlgraph.Node.get_subclasses()
-        if node.label in subclasses_labels
-    ]
+    if args.get('category'):
+        subclasses_labels = [
+            node
+            for node in dictionary.schema
+            if dictionary.schema[node]['category'] in args['category']
+        ]
+        subclasses = [
+            node
+            for node in psqlgraph.Node.get_subclasses()
+            if node.label in subclasses_labels
+        ]
+    else:
+        subclasses = [psqlgraph.Node]
 
     q_all = []
     for subclass in subclasses:

--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -391,8 +391,28 @@ def resolve_node(self, info, **args):
         (not a gdcdatamodel Case)).
 
     """
-    q = query_with_args(psqlgraph.Node, args, info)
-    return [__gql_object_classes[n.label](**load_node(n, info, Node.fields_depend_on_columns)) for n in q.all()]
+
+    # get the list of categories queried by the user
+    # if no specified category, get the list of all categories
+    subclasses_labels = [
+        node
+        for node in dictionary.schema
+        if (not 'category' in args) or (dictionary.schema[node]['category'] in args['category'])
+    ]
+
+    # get the subclass for each category
+    subclasses = [
+        node
+        for node in psqlgraph.Node.get_subclasses()
+        if node.label in subclasses_labels
+    ]
+
+    q_all = []
+    for subclass in subclasses:
+        q = query_with_args(subclass, args, info)
+        q_all.extend(q.all())
+
+    return [__gql_object_classes[n.label](**load_node(n, info, Node.fields_depend_on_columns)) for n in q_all]
 
 
 def query_with_args(cls, args, info):
@@ -494,6 +514,7 @@ def get_node_interface_args():
     return dict(get_base_node_args(), **dict(
         of_type=graphene.List(graphene.String),
         project_id=graphene.String(),
+        category=graphene.String(),
     ))
 
 


### PR DESCRIPTION
- `node` can now be queried by `category`

- Querying `{ node { type } }` does not return the `program` and `project` nodes. Querying `{ node (category: "administrative") { type } }` will