### PR TITLE
chore(Jenkinsfile): add Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+
+@Library('cdis-jenkins-lib@master') _
+
+testPipeline { 
+}


### PR DESCRIPTION
Add a `Jenkinsfile` to run our integration test pipeline against Peregrine PR's

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

