### PR TITLE
(chore(urllib3): bump urllib3 for tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ envelopes==0.4
 -e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.1#egg=sheepdog
 # dependencies of fence
 pyasn1-modules==0.0.11
-urllib3==1.22
+urllib3==1.23
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
 -e git+https://git@github.com/uc-cdis/cirrus.git@0.1.5#egg=cirrus-0.1.5
 -e git+https://git@github.com/uc-cdis/fence.git@2.2.3#egg=fence


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- urllib3 1.22->1.23 for tests to address security vulnerability

### Deployment changes

