### PR TITLE
PXP-1421 Fix/first

### DIFF
--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -885,6 +885,7 @@ def resolve_datanode(self, info, **args):
         q_all.extend(q.all())
 
     limit = args.get('first', DEFAULT_LIMIT)
+    limit = limit if limit > 0 else None
     return [__gql_object_classes[n.label](**load_node(n, info)) for n in q_all][:limit]
 
 
@@ -995,6 +996,7 @@ def apply_nodetype_args(data, args):
         l = sorted(l, key=lambda d: d[args['order_by_desc']], reverse=True)
 
     limit = args.get('first', DEFAULT_LIMIT)
+    limit = limit if limit > 0 else None
     l = l[:limit]
 
     return l

--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -884,6 +884,8 @@ def resolve_datanode(self, info, **args):
         q = query_with_args(data_type, args, info)
         q_all.extend(q.all())
 
+    # apply_arg_limit() applied the limit to individual query results, but we
+    # are concatenating several query results so we need to apply it again
     limit = args.get('first', DEFAULT_LIMIT)
     limit = limit if limit > 0 else None
     return [__gql_object_classes[n.label](**load_node(n, info)) for n in q_all][:limit]
@@ -995,6 +997,8 @@ def apply_nodetype_args(data, args):
     if 'order_by_desc' in args:
         l = sorted(l, key=lambda d: d[args['order_by_desc']], reverse=True)
 
+    # apply_arg_limit() applied the limit to individual query results, but we
+    # are concatenating several query results so we need to apply it again
     limit = args.get('first', DEFAULT_LIMIT)
     limit = limit if limit > 0 else None
     l = l[:limit]


### PR DESCRIPTION
Fix for `first=0` for `datanode` and `_node_type`

### New Features

### Breaking Changes


### Bug Fixes
- Fixes the argument `first` in `datanode` and `_node_type` interfaces so that `first=0` will return all the results

### Improvements


### Dependency updates


### Deployment changes

