### PR TITLE
fix(node-submitterid): add submitter_id to node interface

### DIFF
--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -500,6 +500,7 @@ def get_node_class_property_args(cls, not_props_io={}):
 def get_base_node_args():
     return dict(
         id=graphene.String(),
+        submitter_id=graphene.String(),
         ids=graphene.List(graphene.String),
         quick_search=graphene.String(),
         first=graphene.Int(default_value=DEFAULT_LIMIT),

--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -244,6 +244,12 @@ def apply_query_args(q, args, info):
     if 'ids' in args:
         q = q.ids(args.get('ids'))
 
+    # submitter_id: filter for those with submitter_ids in a given list
+    if q.entity().label == 'node' and 'submitter_id' in args:
+        val = args['submitter_id']
+        val = val if isinstance(val, list) else [val]
+        q = q.filter(q.entity()._props['submitter_id'].astext.in_([str(v) for v in val]))
+
     # quick_search: see ``apply_arg_quicksearch``
     if 'quick_search' in args:
         q = apply_arg_quicksearch(q, args, info)

--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -373,6 +373,7 @@ class Node(graphene.Interface):
     """The query object that represents the psqlgraph.Node base"""
 
     id = graphene.ID()
+    submitter_id = graphene.String()
     type = graphene.String()
     project_id = graphene.String()
     created_datetime = graphene.String()


### PR DESCRIPTION
This gives the `Node` interface access to the `submitter_id` field. All the nodes have a `submitter_id`, except `program` and `project` nodes, so their `submitter_id` will be null.
This is needed for the data upload feature.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Add the `submitter_id` field to the `Node` interface

### Dependency updates


### Deployment changes

