### PR TITLE
PXD-2355: lazy load traversal cache

### DIFF
--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -113,7 +113,7 @@ def app_init(app):
     # exclude es init as it's not used yet
     # es_init(app)
     cors_init(app)
-    app.graph_traversals = submission.graphql.make_graph_traversal_dict(app.logger)
+    submission.graphql.make_graph_traversal_dict(app)
     app.graphql_schema = submission.graphql.get_schema()
     app.schema_file = submission.generate_schema_file(app.graphql_schema, app.logger)
     try:

--- a/peregrine/dev_settings.py
+++ b/peregrine/dev_settings.py
@@ -76,3 +76,4 @@ SESSION_COOKIE_NAME = 'PEREGRINE_session'
 # verify project existence in dbgap or not
 VERIFY_PROJECT = False
 AUTH_SUBMISSION_LIST = False
+USE_LAZY_TRAVERSE = True


### PR DESCRIPTION
fix(lazy-traverse)
- [x] waiting for Travis to finish
* No tests found for traversal code, suggest a new ticket to cover them
* Also added config `USE_LAZY_TRAVERSE` to revert to old behavior
* May easily implement "after-start-up preload" based on this PR


### Breaking Changes
* First few GraphQL queries with `with_path_to` filter may be slower.

### Deployment changes
* Now the traversal cache is no longer loaded at startup, so it should be faster to start