### PR TITLE
Fix/transaction log tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 
 # command to run tests
 script:
-  - py.test -vv --cov=peregrine --cov-report xml tests/system_test.py tests/graphql/test_graphql.py tests/graphql/test_datasets.py
+  - py.test -vv --cov=peregrine --cov-report xml tests
 
 after_script:
   - python-codacy-coverage -r coverage.xml
@@ -43,3 +43,4 @@ after_script:
 env:
   global:
     - GDC_ES_HOST=localhost
+

--- a/peregrine/resources/submission/graphql/transaction.py
+++ b/peregrine/resources/submission/graphql/transaction.py
@@ -189,6 +189,11 @@ class TransactionDocument(graphene.ObjectType):
     response_json = graphene.String()
     response = graphene.Field(TransactionResponse)
 
+    # These fields depend on these columns being loaded
+    fields_depend_on_columns = {
+        "doc_size": {"doc"},
+    }
+
     @classmethod
     def resolve_doc_size(cls, document, *args, **kwargs):
         return len(document.doc)
@@ -244,7 +249,7 @@ class TransactionLog(graphene.ObjectType):
 
     def resolve_documents(self, info, **args):
         return [TransactionDocument(**dict(
-            filtered_column_dict(r, info),
+            filtered_column_dict(r, info, TransactionDocument.fields_depend_on_columns),
             **{'response_json': json.dumps(r.response_json)}
         )) for r in self.documents]
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,4 +11,4 @@ userdatamodel-init --db test_userapi
 python bin/setup_test_database.py
 mkdir -p tests/resources/keys; cd tests/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem; cd -
 
-py.test -vv --cov=peregrine --cov-report xml tests/system_test.py tests/graphql/test_graphql.py tests/graphql/test_datasets.py
+py.test -vv --cov=peregrine --cov-report xml tests

--- a/tests/graphql/test_graphql.py
+++ b/tests/graphql/test_graphql.py
@@ -18,69 +18,6 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 path = '/v0/submission/graphql'
 
-# ======================================================================
-# Fixtures
-
-@pytest.fixture
-def graphql_client(client, submitter):
-    def execute(query, variables={}):
-        return client.post(path, headers=submitter, data=json.dumps({
-            'query': query,
-            'variables': variables,
-        }))
-    return execute
-
-
-@pytest.fixture
-def mock_tx_log(pg_driver_clean):
-    utils.reset_transactions(pg_driver_clean)
-    with pg_driver_clean.session_scope() as session:
-        return session.merge(models.submission.TransactionLog(
-            is_dry_run=True,
-            program='CGCI',
-            project='BLGSP',
-            role='create',
-            state='SUCCEEDED',
-            committed_by=12345,
-            closed=False,
-        ))
-
-
-@pytest.fixture
-def populated_blgsp(client, submitter, pg_driver_clean):
-    utils.reset_transactions(pg_driver_clean)
-    post_example_entities_together(client, pg_driver_clean, submitter)
-
-
-@pytest.fixture
-def failed_deletion_transaction(client, submitter, pg_driver_clean, populated_blgsp):
-    with pg_driver_clean.session_scope():
-        node_id = pg_driver_clean.nodes(models.Sample).first().node_id
-    delete_path = '/v0/submission/CGCI/BLGSP/entities/{}'.format(node_id)
-    r = client.delete(
-        delete_path,
-        headers=submitter)
-    assert r.status_code == 400, r.data
-    return str(r.json['transaction_id'])
-
-
-@pytest.fixture
-def failed_upload_transaction(client, submitter, pg_driver_clean):
-    put_path = '/v0/submission/CGCI/BLGSP/'
-    r = client.put(
-        put_path,
-        data=json.dumps({
-            'type': 'sample',
-            'cases': [{'id': 'no idea'}],
-            'sample_type': 'teapot',
-            'how_heavy': 'no',
-        }),
-        headers=submitter)
-    assert r.status_code == 400, r.data
-    return str(r.json['transaction_id'])
-
-# ======================================================================
-# Tests
 
 def post_example_entities_together(
         client, pg_driver_clean, submitter, data_fnames=data_fnames):

--- a/tests/graphql/test_transaction_logs.py
+++ b/tests/graphql/test_transaction_logs.py
@@ -327,20 +327,18 @@ def test_transaction_log_entities(client, submitter, pg_driver_clean, cgci_blgsp
     utils.reset_transactions(pg_driver_clean)
     post_example_entities_together(client, pg_driver_clean, submitter)
 
-    # "response" is always empty so this fails
-    # TODO: fix response
-    # r = client.post(path, headers=submitter(path, 'post'), data=json.dumps({
-    #     'query': """{ log: transaction_log {
-    #     doc: documents { resp: response { ent: entities { type }}}}}"""}))
-    # print r.data
-    # assert r.status_code == 200
-    # entities = r.json['data']['log'][0]['doc'][0]['resp']['ent']
-    # assert all(e['type'] for e in entities)
+    # using response
+    r = client.post(path, headers=submitter, data=json.dumps({
+        'query': """{ log: transaction_log {
+        doc: documents { resp: response { ent: entities { type }}}}}"""}))
+    assert r.status_code == 200
+    entities = r.json['data']['log'][0]['doc'][0]['resp']['ent']
+    assert all(e['type'] for e in entities)
 
+    # using response_json
     r = client.post(path, headers=submitter, data=json.dumps({
         'query': """{ log: transaction_log {
         doc: documents { resp: response_json }}}"""}))
-    print r.data
     assert r.status_code == 200
     resp = json.loads(r.json['data']['log'][0]['doc'][0]['resp'])
     assert all(entity['type'] for entity in resp['entities'])
@@ -355,20 +353,20 @@ def test_transaction_log_entities_errors(
     )
     transaction_id = put_response.json.get('transaction_id')
 
-    # "response" is always empty so this fails
-    # TODO: fix response
-    # query = """
-    # {{ log: transaction_log( id: {} ) {{
-    #     doc: documents {{ resp: response {{ ent: entities {{
-    #     err: errors {{ type keys message }} }} }} }} }} }}
-    # """
-    # query = query.format(transaction_id)
-    # r = client.post(path, headers=submitter(path, 'post'), data=json.dumps({
-    #     'query': query
-    # }))
-    # assert r.status_code == 200
-    # error = r.json['data']['log'][0]['doc'][0]['resp']['ent'][0]['err'][0]
+    # using response
+    query = """
+    {{ log: transaction_log( id: {} ) {{
+        doc: documents {{ resp: response {{ ent: entities {{
+        err: errors {{ type keys message }} }} }} }} }} }}
+    """
+    query = query.format(transaction_id)
+    r = client.post(path, headers=submitter, data=json.dumps({
+        'query': query
+    }))
+    assert r.status_code == 200
+    error = r.json['data']['log'][0]['doc'][0]['resp']['ent'][0]['err'][0]
 
+    # using response_json
     query = """
     {{ log: transaction_log( id: {} ) {{
         doc: documents {{ resp: response_json

--- a/tests/graphql/test_transaction_logs.py
+++ b/tests/graphql/test_transaction_logs.py
@@ -382,10 +382,6 @@ def test_transaction_log_entities_errors(
     assert all(key in error for key in ('type', 'keys', 'message'))
 
 
-# "doc_size" is always empty so this test fails
-# also, bug "object of type 'NoneType' has no len()"
-# TODO: fix doc_size
-@pytest.mark.skip(reason='"doc_size" is always empty so this test fails')
 def test_transaction_log_documents(client, submitter, pg_driver_clean, cgci_blgsp):
 
     utils.reset_transactions(pg_driver_clean)
@@ -393,7 +389,6 @@ def test_transaction_log_documents(client, submitter, pg_driver_clean, cgci_blgs
     r = client.post(path, headers=submitter, data=json.dumps({
         'query': """{ log: transaction_log {
         doc: documents { doc_size name }}}"""}))
-    print r.data
     doc = r.json['data']['log'][0]['doc'][0]
     assert doc['name'] is None
     assert isinstance(doc['doc_size'], int)


### PR DESCRIPTION
- Re-enable and fix transaction_logs tests
- Refactor test fixtures
- Fix transaction logs resolution

### Bug Fixes
- transaction_log `response` field was always null
- transaction_log `doc_size` field threw an error when the `doc` field was not also queried

### Improvements
- travis now runs all the tests
