### PR TITLE
fix(datanode-array)

### DIFF
--- a/peregrine/resources/submission/graphql/node.py
+++ b/peregrine/resources/submission/graphql/node.py
@@ -509,12 +509,13 @@ def query_node_with_args(args, info):
 
 
 def lookup_graphql_type(T):
+    # XXX: for now all arrays are assumed to contain string items.
     return {
         bool: graphene.Boolean,
         float: graphene.Float,
         long: graphene.Float,
         int: graphene.Int,
-        list: graphene.List(graphene.String),
+        list: graphene.List(graphene.String), # XXX: graphene.List(item_type)
     }.get(T, graphene.String)
 
 


### PR DESCRIPTION
Fixes a bug when a data node contains an array field (such as https://github.com/uc-cdis/ndhdictionary/blob/0c5f2a97a3fa470d31e6886b7483d036cd5e81a4/gdcdictionary/schemas/sequencing_result.yaml#L102)

```
lookup_graphql_type(types[0])()
TypeError: 'List' object is not callable
```

Also add a note for future; we should instantiate array fields by doing `graphene.List(actual type of the items)` but for now we assume the items are String.

### Bug Fixes
- Fix bug when a data node contains an array field
