### PR TITLE
bump sqlalchemy, pyyaml, bunch of other stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,7 @@ WORKDIR /peregrine
 
 RUN pip install -r requirements.txt \
     && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >peregrine/version_data.py \
-    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>peregrine/version_data.py \
-    && echo "DICTCOMMIT=\"(TODO)\"" >>/peregrine/peregrine/version_data.py \
-    && echo "DICTVERSION=\"(TODO)\"" >>/peregrine/peregrine/version_data.py
-
-
-#    && cd /peregrine/lib/python2.7/site-packages/gdcdictionary \
-#    && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
-#    && DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/peregrine/peregrine/version_data.py \
-#    && python setup.py install
+    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>peregrine/version_data.py
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /peregrine
 RUN pip install -r requirements.txt \
     && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >peregrine/version_data.py \
     && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>peregrine/version_data.py \
-    && cd /peregrine/src/gdcdictionary && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
+    && cd /peregrine/lib/python2.7/site-packages/gdcdictionary \
+    && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
     && DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/peregrine/peregrine/version_data.py \
     && python setup.py install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,14 @@ WORKDIR /peregrine
 RUN pip install -r requirements.txt \
     && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >peregrine/version_data.py \
     && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>peregrine/version_data.py \
-    && cd /peregrine/lib/python2.7/site-packages/gdcdictionary \
-    && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
-    && DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/peregrine/peregrine/version_data.py \
-    && python setup.py install
+    && echo "DICTCOMMIT=\"(TODO)\"" >>/peregrine/peregrine/version_data.py \
+    && echo "DICTVERSION=\"(TODO)\"" >>/peregrine/peregrine/version_data.py
+
+
+#    && cd /peregrine/lib/python2.7/site-packages/gdcdictionary \
+#    && DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >>/peregrine/peregrine/version_data.py \
+#    && DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/peregrine/peregrine/version_data.py \
+#    && python setup.py install
 
 EXPOSE 80
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,6 @@ Sphinx==1.3.1
 sphinxcontrib-httpdomain==1.3.0
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
--e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.4#egg=flask_postgres_session
 # dependency of sheepdog
 envelopes==0.4
 -e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.13#egg=sheepdog

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,9 +9,9 @@ codacy-coverage
 moto==0.4.5
 Sphinx==1.3.1
 sphinxcontrib-httpdomain==1.3.0
--e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
+-e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.4#egg=flask_postgres_session
 # dependency of sheepdog
 envelopes==0.4
--e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.12#egg=sheepdog
+-e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.13#egg=sheepdog

--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -5,7 +5,7 @@ import logging
 import pkg_resources
 
 from flask import Flask, jsonify
-from flask.ext.cors import CORS
+from flask_cors import CORS
 from flask_sqlalchemy_session import flask_scoped_session
 from psqlgraph import PsqlGraphDriver
 

--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -11,7 +11,6 @@ from psqlgraph import PsqlGraphDriver
 
 from authutils import AuthError
 import datamodelutils
-import gdcdictionary
 from dictionaryutils import DataDictionary, dictionary as dict_init
 from cdispyutils.log import get_handler
 from cdispyutils.uwsgi import setup_user_harakiri

--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import logging
+import pkg_resources
 
 from flask import Flask, jsonify
 from flask.ext.cors import CORS
@@ -10,6 +11,7 @@ from psqlgraph import PsqlGraphDriver
 
 from authutils import AuthError
 import datamodelutils
+import gdcdictionary
 from dictionaryutils import DataDictionary, dictionary as dict_init
 from cdispyutils.log import get_handler
 from cdispyutils.uwsgi import setup_user_harakiri
@@ -19,7 +21,7 @@ from peregrine import dictionary
 from peregrine.blueprints import datasets
 from .errors import APIError, setup_default_handlers, UnhealthyCheck
 from .resources import submission
-from .version_data import VERSION, COMMIT, DICTVERSION, DICTCOMMIT
+from .version_data import VERSION, COMMIT
 
 
 # recursion depth is increased for complex graph traversals
@@ -155,8 +157,7 @@ def health_check():
 @app.route('/_version', methods=['GET'])
 def version():
     dictver = {
-        'version': DICTVERSION,
-        'commit': DICTCOMMIT,
+        'version': pkg_resources.get_distribution("gdcdictionary").version
     }
     base = {
         'version': VERSION,

--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -155,8 +155,10 @@ def health_check():
 
 @app.route('/_version', methods=['GET'])
 def version():
+    # dictver['commit'] deprecated; see peregrine#130
     dictver = {
-        'version': pkg_resources.get_distribution("gdcdictionary").version
+        'version': pkg_resources.get_distribution("gdcdictionary").version,
+        'commit': '',
     }
     base = {
         'version': VERSION,

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ six==1.10.0
 urllib3==1.24.1
 wsgiref==0.1.2
 dicttoxml==1.5.8
-sqlalchemy==0.9.9
+sqlalchemy==1.3.3
 python-dateutil==2.4.2
 graphene==2.0.1
 graphql-relay==0.4.5
@@ -35,7 +35,7 @@ cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 -e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
--e git+https://git@github.com/NCI-GDC/psqlgraph.git@5cddf49dd03a25bd4e553161d7ad7b9a6fe0ac0d#egg=psqlgraph
+-e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.1#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ six==1.10.0
 urllib3==1.24.1
 wsgiref==0.1.2
 dicttoxml==1.5.8
-sqlalchemy==1.3.3
+sqlalchemy==1.3.5
 python-dateutil==2.4.2
 graphene==2.0.1
 graphql-relay==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ Werkzeug==0.9.6
 boto==2.36.0
 elasticsearch==1.2.0
 itsdangerous==0.24
-requests== 2.20.1
+requests== 2.22.0
 six==1.10.0
 urllib3==1.24.1
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Flask==0.12.4
 Flask-Cors==1.9.0
 Jinja2==2.7.3
 MarkupSafe==0.23
-PyYAML==3.11
+PyYAML==5.1
 Werkzeug==0.9.6
 boto==2.36.0
 elasticsearch==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,9 +34,8 @@ promise==2.2.1
 cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
 psqlgraph==2.0.2
+gen3datamodel==2.0.2
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
-#-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/sqlalchemy#egg=gdcdatamodel
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.1#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 authutils==3.1.1
-datamodelutils==0.4.4
+datamodelutils==0.4.7
 defusedxml==0.5.0
 dictionaryutils==2.0.7
 gdcdictionary==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+datamodelutils==0.4.4
 defusedxml==0.5.0
+dictionaryutils==2.0.7
+gdcdictionary==1.2.0
 SurvivalPy==1.0.2
 simplejson==3.8.1
 stopit==1.1.1
@@ -30,14 +33,11 @@ promise==2.2.1
 cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
--e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
 -e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
 -e git+https://git@github.com/NCI-GDC/psqlgraph.git@5cddf49dd03a25bd4e553161d7ad7b9a6fe0ac0d#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.1#egg=storageclient
--e git+https://git@github.com/uc-cdis/dictionaryutils.git@2.0.4#egg=dictionaryutils
--e git+https://git@github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://git@github.com/uc-cdis/graphql-core.git@cdis2.0.0#egg=graphql-core
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,8 @@ promise==2.2.1
 cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
+#-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/sqlalchemy#egg=gdcdatamodel
 -e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-authutils==3.0.6
+authutils==3.1.1
 datamodelutils==0.4.4
 defusedxml==0.5.0
 dictionaryutils==2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+authutils==3.0.6
 datamodelutils==0.4.4
 defusedxml==0.5.0
 dictionaryutils==2.0.7
@@ -41,4 +42,3 @@ cdispyutils==0.2.13
 -e git+https://git@github.com/uc-cdis/graphql-core.git@cdis2.0.0#egg=graphql-core
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
--e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,10 +33,10 @@ graphql-relay==0.4.5
 promise==2.2.1
 cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
+psqlgraph==2.0.2
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 #-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
 -e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/sqlalchemy#egg=gdcdatamodel
--e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.1#egg=storageclient


### PR DESCRIPTION
PyYAML:
Happily, Peregrine was already using PyYAML's `safe_load()` instead of `load()`. So we were good to just bump. 

gdcdictionary: 
Now that gdcdictionary is a PyPI package its location in the Docker container changed. So the `cd` in the RUN part of the Dockerfile broke. The `cd` along with the lines after it served to write version information about gdcdictionary to `version_data.py`. This PR changes the Peregrine `/_version` endpoint to just get the gdcdictionary version programmatically, so that we can remove the broken lines in the Dockerfile. The dictionary commit hash is removed entirely now that we are getting gdcdictionary via PyPI. 

flask:
import CORS from flask_cors not flask.ext.cors


### Improvements
change the Peregrine /_version endpoint to just get the gdcdictionary version programmatically, so that we can remove recently-broken lines in the Dockerfile

### Dependency updates
bump sqlalchemy 0.9.9 to 1.3.5
bump psqlgraph
bump gen3datamodel 
bump datamodelutils
bump dictionaryutils
bump gdcdictionary
bump authutils
bump pyyaml to 5.1 
remove flask-postgres-session (was unused)
bump sheepdog

