### PR TITLE
[PXP-3221] Refactor/fence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ install:
   - pip install -r dev-requirements.txt
 
 before_script:
-  - psql -c "create database test_userapi" -U postgres
-  - userdatamodel-init --db test_userapi
   - pip freeze
   - python bin/setup_test_database.py
   - mkdir -p tests/resources/keys; cd tests/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem; cd -

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,10 +16,3 @@ sphinxcontrib-httpdomain==1.3.0
 # dependency of sheepdog
 envelopes==0.4
 -e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.1#egg=sheepdog
-# dependencies of fence
-pyasn1-modules==0.0.11
-urllib3==1.23
--e git+https://git@github.com/uc-cdis/cirrus.git@0.1.5#egg=cirrus-0.1.5
--e git+https://git@github.com/uc-cdis/fence.git@2.2.3#egg=fence
-# userdatamodel is required by fence
--e git+https://git@github.com/uc-cdis/userdatamodel.git@1.1.4#egg=userdatamodel

--- a/peregrine/test_settings.py
+++ b/peregrine/test_settings.py
@@ -56,8 +56,6 @@ OAUTH2 = {
 DICTIONARY_URL = os.environ.get('DICTIONARY_URL','https://s3.amazonaws.com/dictionary-artifacts/datadictionary/develop/schema.json')
 
 USER_API = "http://localhost"
-# used by fence.jwt.token.generate_signed_access_token for iss
-BASE_URL = "http://localhost"
 
 VERIFY_PROJECT = False
 AUTH_SUBMISSION_LIST = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import sheepdog
 import peregrine
 from peregrine.api import app as _app, app_init
 from peregrine.auth import ROLES
-from fence.jwt.token import generate_signed_access_token
 import utils
 
 here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -141,14 +140,14 @@ def encoded_jwt(app):
 
         Args:
             private_key (str): private key
-            user (userdatamodel.models.User): user object
+            user (generic User object): user object
 
         Return:
             str: JWT containing claims encoded with private key
         """
         kid = peregrine.test_settings.JWT_KEYPAIR_FILES.keys()[0]
         scopes = ['openid']
-        token = generate_signed_access_token(
+        token = utils.generate_signed_access_token(
             kid, private_key, user, 3600, scopes, forced_exp_time=None,
             iss=app.config['USER_API'],
         )
@@ -159,7 +158,7 @@ def encoded_jwt(app):
 @pytest.fixture(scope='session')
 def random_user(encoded_jwt):
     private_key = utils.read_file('resources/keys/test_private_key.pem')
-    # set up a fake User object which has all the attributes that fence needs
+    # set up a fake User object which has all the attributes needed
     # to generate a token
     project_ids = []
     user_properties = {
@@ -178,7 +177,7 @@ def random_user(encoded_jwt):
 @pytest.fixture(scope='session')
 def submitter(encoded_jwt):
     private_key = utils.read_file('resources/keys/test_private_key.pem')
-    # set up a fake User object which has all the attributes that fence needs
+    # set up a fake User object which has all the attributes needed
     # to generate a token
     project_ids = ['phs000218', 'phs000235', 'phs000178']
     user_properties = {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,15 @@
+import json
 import os
+import time
+import uuid
+
+from authlib.common.encoding import to_unicode
+import jwt
+
+from cdislogging import get_logger
+
+
+logger = get_logger(__name__, log_level="info")
 
 
 def read_file(filename):
@@ -7,3 +18,107 @@ def read_file(filename):
     with open(os.path.join(root_dir, filename), 'r') as f:
         return f.read()
 
+class JWTResult(object):
+    """
+    Just a container for the results necessary to keep track of from generating
+    a JWT.
+    """
+
+    def __init__(self, token=None, kid=None, claims=None):
+        self.token = token
+        self.kid = kid
+        self.claims = claims
+
+
+def issued_and_expiration_times(seconds_to_expire):
+    """
+    Return the times in unix time that a token is being issued and will be
+    expired (the issuing time being now, and the expiration being
+    ``seconds_to_expire`` seconds after that). Used for constructing JWTs
+    Args:
+        seconds_to_expire (int): lifetime in seconds
+    Return:
+        Tuple[int, int]: (issued, expired) times in unix time
+    """
+    iat = int(time.time())
+    exp = iat + int(seconds_to_expire)
+    return (iat, exp)
+
+
+def generate_signed_access_token(
+    kid,
+    private_key,
+    user,
+    expires_in,
+    scopes,
+    iss=None,
+    forced_exp_time=None,
+    client_id=None,
+    linked_google_email=None,
+):
+    """
+    Usually, this token is obtained from an outside service.
+    We just simulate that here in order to not import any services.
+
+    Generate a JWT access token and output a UTF-8
+    string of the encoded JWT signed with the private key.
+    Args:
+        kid (str): key id of the keypair used to generate token
+        private_key (str): RSA private key to sign and encode the JWT with
+        user (generic User object): User to generate ID token for
+        expires_in (int): seconds until expiration
+        scopes (List[str]): oauth scopes for user
+    Return:
+        str: encoded JWT access token signed with ``private_key``
+    """
+    headers = {"kid": kid}
+    iat, exp = issued_and_expiration_times(expires_in)
+    # force exp time if provided
+    exp = forced_exp_time or exp
+    sub = str(user.id)
+    jti = str(uuid.uuid4())
+    if not iss:
+        try:
+            iss = config.get("BASE_URL")
+        except RuntimeError:
+            raise ValueError(
+                "must provide value for `iss` (issuer) field if"
+                " running outside of flask application"
+            )
+
+    claims = {
+        "pur": "access",
+        "aud": scopes,
+        "sub": sub,
+        "iss": iss,
+        "iat": iat,
+        "exp": exp,
+        "jti": jti,
+        "context": {
+            "user": {
+                "name": user.username,
+                "is_admin": user.is_admin,
+                "projects": dict(user.project_access),
+                "google": {"proxy_group": user.google_proxy_group_id},
+            }
+        },
+        "azp": client_id or "",
+    }
+
+    # only add google linkage information if provided
+    if linked_google_email:
+        claims["context"]["user"]["google"][
+            "linked_google_account"
+        ] = linked_google_email
+
+    logger.info("issuing JWT access token with id [{}] to [{}]".format(jti, sub))
+    logger.debug("issuing JWT access token\n" + json.dumps(claims, indent=4))
+
+    token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
+    token = to_unicode(token, "UTF-8")
+
+    # Browser may clip cookies larger than 4096 bytes
+    if len(token) > 4096:
+        raise JWTSizeError("JWT exceeded 4096 bytes")
+
+    return JWTResult(token=token, kid=kid, claims=claims)


### PR DESCRIPTION
Remove pyasn1-modules, urllib3, cirrus, userdatamodel, and fence from dev-requirements.txt; just inline the code for token generation (= copy paste a bunch of code from fence/fence/jwt/token to peregrine/tests/utils, but at least fence is no longer a dependency)


### Dependency updates
Remove pyasn1-modules, urllib3, cirrus, userdatamodel, and fence from dev-requirements

