### PR TITLE
Remove signpost

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,10 +9,10 @@ codacy-coverage
 moto==0.4.5
 Sphinx==1.3.1
 sphinxcontrib-httpdomain==1.3.0
--e git+https://git@github.com/uc-cdis/indexclient.git@1.0#egg=indexclient
+-e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/signpost.git@c8e2aa5ff572c808cba9b522b64f7b497e79c524#egg=signpost
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
--e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.1#egg=flask_postgres_session
+-e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.4#egg=flask_postgres_session
 # dependency of sheepdog
 envelopes==0.4
 -e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.1#egg=sheepdog

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,6 @@ moto==0.4.5
 Sphinx==1.3.1
 sphinxcontrib-httpdomain==1.3.0
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
--e git+https://git@github.com/NCI-GDC/signpost.git@c8e2aa5ff572c808cba9b522b64f7b497e79c524#egg=signpost
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.4#egg=flask_postgres_session
 # dependency of sheepdog

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,4 +14,4 @@ sphinxcontrib-httpdomain==1.3.0
 -e git+https://git@github.com/uc-cdis/flask-postgres-session.git@0.1.4#egg=flask_postgres_session
 # dependency of sheepdog
 envelopes==0.4
--e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.1#egg=sheepdog
+-e git+https://git@github.com/uc-cdis/sheepdog.git@1.1.12#egg=sheepdog

--- a/peregrine/dev_settings.py
+++ b/peregrine/dev_settings.py
@@ -2,9 +2,9 @@ import os
 from boto.s3.connection import OrdinaryCallingFormat
 from os import environ as env
 
-# Signpost
-SIGNPOST = {
-   'host': env.get('SIGNPOST_HOST', 'http://localhost:8888'),
+# IndexClient
+INDEX_CLIENT = {
+   'host': env.get('INDEX_CLIENT_HOST', 'http://localhost:8888'),
    'version': 'v0',
    'auth': None}
 

--- a/peregrine/test_settings.py
+++ b/peregrine/test_settings.py
@@ -2,7 +2,7 @@ import os
 from collections import OrderedDict
 
 
-SIGNPOST = {
+INDEX_CLIENT = {
     "host": "http://localhost:8000/", 'version': 'v0',
     "auth": None}
 AUTH = 'https://fake_auth_url'

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ cyordereddict==1.0.0
 Flask-SQLAlchemy-Session==1.1
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 -e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.6#egg=gdcdatamodel
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/temp-until-sqla-upd#egg=gdcdatamodel #TODO
 -e git+https://git@github.com/NCI-GDC/psqlgraph.git@5cddf49dd03a25bd4e553161d7ad7b9a6fe0ac0d#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
 cdispyutils==0.2.13

--- a/run.py
+++ b/run.py
@@ -58,7 +58,7 @@ def fake_get_nodes(dids):
     return nodes
 
 
-def fake_urls_from_signpost(did):
+def fake_urls_from_index_client(did):
     return ["s3://fake-host/fake_bucket/{}".format(did)]
 
 
@@ -116,7 +116,7 @@ def run_with_fake_download():
         with patch.multiple("peregrine.download",
                             key_for=fake_key_for,
                             key_for_node=fake_key_for_node,
-                            urls_from_signpost=fake_urls_from_signpost):
+                            urls_from_index_client=fake_urls_from_index_client):
             if os.environ.get("GDC_FAKE_AUTH"):
                 run_with_fake_auth()
             else:


### PR DESCRIPTION
Remove signpost from peregrine dependencies and code

### Improvements
- stops importing and using signpost in testing, and stops calling index client signpost where index client is already being used instead of signpost

### Dependency updates
- point gen3datamodel to temporary branch until sqlalchemy and psqlgraph get updated
- bump indexclient to 1.5.7
- bump flaks-postgres-session to 0.1.4
- remove signpost from dev-requirements

### Deployment changes
- look for INDEX_CLIENT instead of SIGNPOST in app.config
- get INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST
