### PR TITLE
fix(arborist): no error for unknown user

### DIFF
--- a/peregrine/auth/__init__.py
+++ b/peregrine/auth/__init__.py
@@ -93,7 +93,11 @@ def get_read_access_projects():
     try:
         mapping = flask.current_app.auth.auth_mapping(current_user.username)
     except ArboristError as e:
-        raise AuthNError("Unable to retrieve auth mapping: {}".format(e))
+        # Arborist errored, or this user is unknown to Arborist
+        logger.warn(
+            "Unable to retrieve auth mapping for user `{}`: {}".format(current_user.username, e)
+        )
+        mapping = {}
 
     with flask.current_app.db.session_scope():
         read_access_projects = [

--- a/tests/graphql/test_graphql.py
+++ b/tests/graphql/test_graphql.py
@@ -1447,3 +1447,18 @@ def test_boolean_filter(client, submitter, pg_driver_clean, cgci_blgsp):
     print("Filtering by boolean=[true,false] should return the experiment:")
     print(r.data)
     assert len(r.json["data"]["experiment"]) == 1
+
+
+def test_arborist_unknown_user(client, pg_driver_clean, submitter, cgci_blgsp, mock_arborist_requests):
+    """
+    Tests that if a logged in user does not exist in the DB, peregrine does
+    not throw an error but gracefully returns no data
+    """
+    post_example_entities_together(client, pg_driver_clean, submitter)
+    mock_arborist_requests(known_user=False)
+    r = client.post(
+        path,
+        headers=submitter,
+        data=json.dumps({"query": "{ project { code } }"})
+    )
+    assert r.json == { "data": { "project": [] } }


### PR DESCRIPTION
users who are not in the user.yaml can't query, they get the error: `Authentication Error: Unable to retrieve auth mapping: [500] - user does not exist: xxx`
Peregrine should return empty data instead

### Bug Fixes
- Return empty data instead of an error when arborist does not recognize a user
