### PR TITLE
Bump flask to 1.1.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 httmock==1.2.3
-pytest>=3.2.3,<4.0.0
+pytest>=4.6.5,<5.0.0
 lockfile==0.10.2
 coverage==3.7.1
 mock==1.0.1
-pytest-flask==0.8.1
+pytest-flask==0.15.0
 pytest-cov==2.5.1
 codacy-coverage
 moto==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,13 +12,13 @@ python-Levenshtein==0.12.0
 python-keystoneclient==1.6.0
 fuzzywuzzy==0.6.1
 addict==0.2.7
-Flask==0.12.4
+Flask==1.1.1
 Flask-Cors==1.9.0
 gen3authz==0.2.1
 Jinja2==2.7.3
 MarkupSafe==0.23
 PyYAML==5.1
-Werkzeug==0.9.6
+Werkzeug==0.16.0
 boto==2.36.0
 elasticsearch==1.2.0
 itsdangerous==0.24

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, here)
 
 
-@pytest.fixture(scope='session')
 def pg_config():
     return dict(
         host='localhost',


### PR DESCRIPTION
Bump flask to the latest version
also bump pytest to 4.6.5 (latest version that supports python 2) and pytest-flask to 0.15.0 (latest version) to fix unit test issues

### Dependency updates
- Flask 1.1.1, Werkzeug 0.16.0