### PR TITLE
version 1 of more granular permission level.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ WORKDIR /$appname
 RUN python -m pip install --upgrade pip \
     && python -m pip install --upgrade setuptools \
     && pip --version \
-    && pip install -r requirements.txt
+    && pip install -r requirements.txt \
+    && pip uninstall cryptography -y \
+    && pip install cryptography==2.8
 
 RUN mkdir -p /var/www/$appname \
     && mkdir -p /var/www/.cache/Python-Eggs/ \

--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -3,6 +3,7 @@ import sys
 import time
 import logging
 import pkg_resources
+import importlib
 
 from flask import Flask, jsonify
 from flask_cors import CORS
@@ -144,6 +145,16 @@ def app_init(app):
     else:
         app.logger.info("Using default Arborist base URL")
         app.auth = ArboristClient()
+
+    app.node_authz_entity_name = os.environ.get("AUTHZ_ENTITY_NAME", None)
+    if app.node_authz_entity_name:
+        full_module_name = "datamodelutils.models"
+        mymodule = importlib.import_module(full_module_name)
+        for i in dir(mymodule):
+            if i.lower() == app.node_authz_entity_name.lower():
+                attribute = getattr(mymodule, i)
+                app.node_authz_entity = attribute
+    
 
     app.logger.info("Initialization complete.")
 

--- a/peregrine/auth/__init__.py
+++ b/peregrine/auth/__init__.py
@@ -14,6 +14,9 @@ from datamodelutils import models
 from gen3authz.client.arborist.errors import ArboristError
 import flask
 
+import itertools
+from operator import itemgetter
+
 
 logger = get_logger(__name__)
 
@@ -25,7 +28,7 @@ def resource_path_to_project_ids(resource_path):
     if resource_path != "/" and parts[0] != "programs":
         return []
 
-    if len(parts) > 4 or (len(parts) > 2 and parts[2] != "projects"):
+    if len(parts) > 6 or (len(parts) > 2 and parts[2] != "projects") or (len(parts) > 4 and parts[4] != (flask.current_app.node_authz_entity_name + "s")):
         logger.warn(
             "ignoring resource path {} because peregrine cannot handle a permission more granular than program/project level".format(
                 resource_path
@@ -37,7 +40,7 @@ def resource_path_to_project_ids(resource_path):
     if len(parts) == 1:
         programs = flask.current_app.db.nodes(models.Program).all()
         return [
-            program.name + "-" + project.code
+            { project_id: program.name + "-" + project.code, node_id: '*' }
             for program in programs
             for project in program.projects
         ]
@@ -56,27 +59,44 @@ def resource_path_to_project_ids(resource_path):
                 )
             )
             return []
-        return [program.name + "-" + project.code for project in program.projects]
+        return [{ project_id: program.name + "-" + project.code, node_id: '*' } for project in program.projects]
 
-    # "/programs/[...]/projects/[...]": access to a specific project
-    # here, len(parts) == 4 and parts[2] == "projects"
+    # "/programs/[...]/projects/[...]" or "/programs/[...]/projects/[...]/{node}s": access to a specific project
+    # access to all nodes in a project
+    if len(parts) < 6:
+        project_code = parts[3]
+        project = (
+            flask.current_app.db.nodes(models.Project).props(code=project_code).first()
+        )
+        if not project:
+            logger.warn(
+                "project {} in resource path {} does not exist".format(
+                    project_code, resource_path
+                )
+            )
+            return []
+        return [ { 'project_id': program.name + "-" + project.code, 'node_id': '*' } for program in project.programs]
+
+    # "/programs/[...]/projects/[...]/{node}s/{submitter_id}": access to a specific project's child node subbranch
+    # here, len(parts) == 6 and parts[4] == (flask.current_app.node_authz_entity_name + "s")
+    program_name = parts[1]
     project_code = parts[3]
-    project = (
-        flask.current_app.db.nodes(models.Project).props(code=project_code).first()
-    )
-    if not project:
+    node_submitter_id = parts[5]
+    node = (
+            flask.current_app.db.nodes(flask.current_app.node_authz_entity).props(submitter_id=node_submitter_id, project_id=program_name + "-" + project_code).first()
+        )
+    if not node:
         logger.warn(
-            "project {} in resource path {} does not exist".format(
-                project_code, resource_path
+            "node {} in resource path {} does not exist".format(
+                node_submitter_id, resource_path
             )
         )
         return []
-    return [program.name + "-" + project.code for program in project.programs]
+    return [ { 'project_id': node.project_id, 'node_id': node.submitter_id } ]
 
-
-def get_read_access_projects():
+def get_read_access_resources():
     """
-    Get all resources the user has read access to and parses the Arborist resource paths into a program.name and a project.code.
+    Get all resources the user has read access to and parses the Arborist resource paths into a program.name, project.code and node id.
     """
     try:
         mapping = flask.current_app.auth.auth_mapping(current_user.username)
@@ -90,10 +110,10 @@ def get_read_access_projects():
         mapping = {}
 
     with flask.current_app.db.session_scope():
-        read_access_projects = [
-            project_id
+        access_resources = [
+            node
             for resource_path, permissions in mapping.items()
-            for project_id in resource_path_to_project_ids(resource_path)
+            for node in resource_path_to_project_ids(resource_path)
             # ignore resource if no peregrine read access:
             if any(
                 permission.get("service") in ["*", "peregrine"]
@@ -102,5 +122,8 @@ def get_read_access_projects():
             )
         ]
 
-    # return unique project_ids
-    return list(set(read_access_projects))
+        sorted_resources = sorted(access_resources, key=itemgetter('project_id'))
+        read_access_resources = {key:[item["node_id"] for item in list(group)] for key, group in itertools.groupby(sorted_resources, key=lambda x:x['project_id'])}
+        
+    # return dictionary of resources with read permissions
+    return read_access_resources

--- a/peregrine/resources/submission/__init__.py
+++ b/peregrine/resources/submission/__init__.py
@@ -12,7 +12,7 @@ from cdiserrors import AuthZError
 import datamodelutils.models as models
 import flask
 
-from peregrine.auth import current_user, get_read_access_projects
+from peregrine.auth import current_user, get_read_access_resources
 import peregrine.blueprints
 from peregrine.resources.submission import graphql
 
@@ -60,10 +60,10 @@ def set_read_access_projects_for_public_endpoint():
 
 def set_read_access_projects():
     """
-    Assign the list of projects (as strings of project ids) for which the user
-    has read access to ``flask.g.read_access_projects``.
+    Assign the list of projects and subjects for which the user
+    has read access to ``flask.g.read_access_permissions``.
 
-    The user has read access, firstly, to the projects for which they directly
+    The user has read access, firstly, to the projects and subjects for which they directly
     have read permissions, and also to projects with availability type marked
     "Open".
 
@@ -78,9 +78,12 @@ def set_read_access_projects():
         assigns result from ``get_open_project_ids`` to
         ``flask.g.read_access_projects``.
     """
-    if not hasattr(flask.g, "read_access_projects"):
-        flask.g.read_access_projects = get_read_access_projects()
+    if not hasattr(flask.g, "read_access_permissions"):
+        read_access_resources = get_read_access_resources()
+        flask.g.read_access_permissions = read_access_resources
+        flask.g.read_access_projects = list(read_access_resources.keys())
         flask.g.read_access_projects.extend(get_open_project_ids())
+    
 
 
 @peregrine.blueprints.blueprint.route("/graphql", methods=["POST"])

--- a/peregrine/resources/submission/graphql/util.py
+++ b/peregrine/resources/submission/graphql/util.py
@@ -137,7 +137,7 @@ def authorization_filter(q):
                 cls = q.entity()
                 q = q.reset_joinpoint()
             else:
-                 print("ERROR: node not found")
+                 print("ERROR: node not found parent of " + str(cls))
 
     if cls == psqlgraph.Node or hasattr(cls, "project_id"):
         # add the filter for project and subject according to the permission assigned to the user

--- a/peregrine/resources/submission/graphql/util.py
+++ b/peregrine/resources/submission/graphql/util.py
@@ -137,7 +137,7 @@ def authorization_filter(q):
                 cls = q.entity()
                 q = q.reset_joinpoint()
             else:
-                 print("ERROR: node not found parent of " + str(cls))
+                 print("WARNING: node not found parent of " + str(cls))
 
     if cls == psqlgraph.Node or hasattr(cls, "project_id"):
         # add the filter for project and subject according to the permission assigned to the user

--- a/peregrine/resources/submission/graphql/util.py
+++ b/peregrine/resources/submission/graphql/util.py
@@ -119,12 +119,13 @@ def authorization_filter(q):
     """
     cls = q.entity()
     authLeafNode = capp.node_authz_entity
+    ands = []
 
     if cls != models.Project and cls != models.Program:
         # if the node is below the subject level than find its path to the subject node and join the needed tables
         if cls != authLeafNode:
             # Assuming there is only one father for each node
-            nodeType = list(cls._pg_links.keys())[0] # "inrgs"
+            nodeType = list(cls._pg_links.keys())[0] 
             path_tmp = nodeType
             tmp = cls._pg_links[nodeType]["dst_type"]
             while tmp != authLeafNode and tmp != models.Program:
@@ -133,11 +134,10 @@ def authorization_filter(q):
                 tmp = tmp._pg_links[nodeType]["dst_type"]
             if tmp == authLeafNode:
                 q = q.path(path_tmp)
+                cls = q.entity()
+                q = q.reset_joinpoint()
             else:
                  print("ERROR: node not found")
-
-    cls = q.entity()
-    ands = []        
 
     if cls == psqlgraph.Node or hasattr(cls, "project_id"):
         # add the filter for project and subject according to the permission assigned to the user
@@ -162,9 +162,6 @@ def authorization_filter(q):
     if cls.label == "project":
         # do not return unauthorized projects
         q = node.filter_project_project_id(q, list(fg.read_access_permissions.keys()), None)
-
-    print("STOP HERE")   
-    print(q, flush=True)
 
     return q
 

--- a/peregrine/resources/submission/graphql/util.py
+++ b/peregrine/resources/submission/graphql/util.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import load_only
 
 import psqlgraph
 
+
 # from peregrine.resources.submission.constants import (
 #     FILTER_ACTIVE,
 # )
@@ -116,18 +117,54 @@ def authorization_filter(q):
         ``project_id`` while maintaining filter correctness.
 
     """
+    cls = q.entity()
+    authLeafNode = capp.node_authz_entity
+
+    if cls != models.Project and cls != models.Program:
+        # if the node is below the subject level than find its path to the subject node and join the needed tables
+        if cls != authLeafNode:
+            # Assuming there is only one father for each node
+            nodeType = list(cls._pg_links.keys())[0] # "inrgs"
+            path_tmp = nodeType
+            tmp = cls._pg_links[nodeType]["dst_type"]
+            while tmp != authLeafNode and tmp != models.Program:
+                nodeType = list(tmp._pg_links.keys())[0]
+                path_tmp = path_tmp + "." + nodeType 
+                tmp = tmp._pg_links[nodeType]["dst_type"]
+            if tmp == authLeafNode:
+                q = q.path(path_tmp)
+            else:
+                 print("ERROR: node not found")
 
     cls = q.entity()
+    ands = []        
 
     if cls == psqlgraph.Node or hasattr(cls, "project_id"):
-        q = q.filter(cls._props["project_id"].astext.in_(fg.read_access_projects))
+        # add the filter for project and subject according to the permission assigned to the user
+        for key,value in fg.read_access_permissions.items():
+            filter_group = list()
+            filter_group.append(cls._props["project_id"].astext == key)
+            
+            if '*' not in value:
+                if cls != models.Project and cls != models.Program and len(value) > 0:
+                    if cls == authLeafNode:
+                        filter_group.append(cls._props["submitter_id"].astext.in_(value))
+                    else:
+                        print("ERROR: node found has wrong structure: ")
+                        print(cls)
+    
+            if filter_group and len(filter_group) > 0:
+                ands.append(sa.and_(*filter_group).self_group())
+
+        if ands and len(ands) > 0:
+            q = q.filter(sa.or_(*ands))
 
     if cls.label == "project":
         # do not return unauthorized projects
-        q = node.filter_project_project_id(q, fg.read_access_projects, None)
+        q = node.filter_project_project_id(q, list(fg.read_access_permissions.keys()), None)
 
-    # if FILTER_ACTIVE:
-    #     q = active_project_filter(q)
+    print("STOP HERE")   
+    print(q, flush=True)
 
     return q
 


### PR DESCRIPTION
### Improvements

This pull request allows peregrine to filter the results of a query one level under Project. This will allow to assign more granular permission to a user. 

/program/{program}/project/{project}/{node}/{submitter_id}

The node name and model is configurable in the environment variable since it can differ among different dictionaries.

