### PR TITLE
PXP-2403 fix duplicate project id bug

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,9 @@
 {
-  "custom_plugin_paths": [],
   "exclude": {
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-07-24T04:30:34Z",
+  "generated_at": "2020-11-16T20:06:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -189,7 +188,7 @@
       }
     ]
   },
-  "version": "0.14.1",
+  "version": "0.13.1",
   "word_list": {
     "file": null,
     "hash": null

--- a/peregrine/resources/submission/__init__.py
+++ b/peregrine/resources/submission/__init__.py
@@ -79,7 +79,6 @@ def set_read_access_projects():
         ``flask.g.read_access_projects``.
     """
     if not hasattr(flask.g, "read_access_projects"):
-        # assumes order need not be preserved
         flask.g.read_access_projects = list(
             set(get_read_access_projects() + get_open_project_ids())
         )

--- a/peregrine/resources/submission/__init__.py
+++ b/peregrine/resources/submission/__init__.py
@@ -79,8 +79,10 @@ def set_read_access_projects():
         ``flask.g.read_access_projects``.
     """
     if not hasattr(flask.g, "read_access_projects"):
-        flask.g.read_access_projects = get_read_access_projects()
-        flask.g.read_access_projects.extend(get_open_project_ids())
+        # assumes order need not be preserved
+        flask.g.read_access_projects = list(
+            set(get_read_access_projects() + get_open_project_ids())
+        )
 
 
 @peregrine.blueprints.blueprint.route("/graphql", methods=["POST"])


### PR DESCRIPTION
OPEN projects are double counted because they appear in both open read access privileges and authorized user level privileges. Bug fix makes sure peregrine is aware of this and does not add project_ids to list of projects if it is already in the list because it's an open project.

https://ctds-planx.atlassian.net/browse/PXP-2403

### Bug Fixes
Fix bug where project id count returns 2 instead of 1

