### PR TITLE
Handle exceptions without 'message' attribute

### DIFF
--- a/peregrine/api.py
+++ b/peregrine/api.py
@@ -197,7 +197,7 @@ def _log_and_jsonify_exception(e):
     if hasattr(e, "json") and e.json:
         return jsonify(**e.json), e.code
     else:
-        return jsonify(message=e.message), e.code
+        return jsonify(message=e.message if hasattr(e, "message") else str(e)), e.code
 
 
 app.register_error_handler(APIError, _log_and_jsonify_exception)

--- a/peregrine/resources/submission/__init__.py
+++ b/peregrine/resources/submission/__init__.py
@@ -150,7 +150,10 @@ def generate_schema_file(graphql_schema, app_logger):
             result = graphql_schema.execute(query)
             data = {"data": result.data}
             if result.errors:
-                data["errors"] = [err.message for err in result.errors]
+                data["errors"] = [
+                    err.message if hasattr(err, "message") else str(err)
+                    for err in result.errors
+                ]
             json.dump(data, f)
 
             end = int(round(time.time() - start))

--- a/peregrine/resources/submission/graphql/__init__.py
+++ b/peregrine/resources/submission/graphql/__init__.py
@@ -123,7 +123,10 @@ def execute_query(query, variables=None, app=None):
         return data, errors
     else:
         if result.errors:
-            errors = [err.message for err in result.errors]
+            errors = [
+                err.message if hasattr(err, "message") else str(err)
+                for err in result.errors
+            ]
         # Generate response
         if "TimeoutException" in errors:
             errors.append(TIMEOUT_MESSAGE.format(GRAPHQL_TIMEOUT))


### PR DESCRIPTION
Fix this error seen in IBD Prod Peregrine:
```
File "/peregrine/peregrine/resources/submission/graphql/__init__.py", line 126, in <listcomp>
    errors = [err.message for err in result.errors]
AttributeError: 'Exception' object has no attribute 'message'
```

relates to https://github.com/uc-cdis/pidgin/pull/40

### Bug Fixes
- Handle exceptions without 'message' attribute
