### PR TITLE
/datasets correctly return an error when no 'nodes' parameter.

### DIFF
--- a/peregrine/blueprints/datasets.py
+++ b/peregrine/blueprints/datasets.py
@@ -22,9 +22,9 @@ def get_datasets():
     anonymous users
     """
     nodes = flask.request.args.get("nodes", "")
-    nodes = nodes.split(",")
     if not nodes:
         raise UserError("Need to provide target nodes in query param")
+    nodes = nodes.split(",")
     if os.environ.get("PUBLIC_DATASETS", "false").lower() == "true":
         set_read_access_projects_for_public_endpoint()
     else:

--- a/tests/graphql/test_datasets.py
+++ b/tests/graphql/test_datasets.py
@@ -95,3 +95,9 @@ def test_get_projects_anonymous(
             {"dbgap_accession_number": "phsid", "code": "OTHER", "name": "name"},
         ]
     }
+
+
+def test_no_nodes_parameter(client, submitter):
+    r = client.get("/datasets", headers=submitter)
+    assert r.status_code == 400, r.text
+    assert r.json["message"] == "Need to provide target nodes in query param"

--- a/tests/graphql/test_datasets.py
+++ b/tests/graphql/test_datasets.py
@@ -98,6 +98,9 @@ def test_get_projects_anonymous(
 
 
 def test_no_nodes_parameter(client, submitter):
+    """
+    The endpoint should require the `nodes` query parameter
+    """
     r = client.get("/datasets", headers=submitter)
     assert r.status_code == 400, r.text
     assert r.json["message"] == "Need to provide target nodes in query param"


### PR DESCRIPTION
Bug: if `nodes == ""`, then `nodes.split(",") == [""]` and we don't run the `if not nodes` statement

### Bug Fixes
- Fix `/datasets` to correctly return an error when no `nodes` parameter is provided
